### PR TITLE
Verify declaration of input parameters

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,12 @@ name: Validate
 
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - v*
 
 jobs:
   validate-commit-messages:
@@ -14,7 +19,7 @@ jobs:
         uses: rainstormy/github-action-validate-commit-messages@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          rules: 'acknowledged-author-email-addresses, acknowledged-author-names, acknowledged-committer-email-addresses, acknowledged-committer-names, capitalised-subject-lines, empty-line-after-subject-lines, imperative-subject-lines, limit-length-of-body-lines, limit-length-of-subject-lines, multi-word-subject-lines, no-co-authors, no-merge-commits, no-revert-revert-commits, no-squash-commits, no-trailing-punctuation-in-subject-lines, no-unexpected-whitespace'
+          rules: acknowledged-author-email-addresses, acknowledged-author-names, acknowledged-committer-email-addresses, acknowledged-committer-names, capitalised-subject-lines, empty-line-after-subject-lines, imperative-subject-lines, limit-length-of-body-lines, limit-length-of-subject-lines, multi-word-subject-lines, no-co-authors, no-merge-commits, no-revert-revert-commits, no-squash-commits, no-trailing-punctuation-in-subject-lines, no-unexpected-whitespace, unique-subject-lines
           acknowledged-author-email-addresses--patterns: '\d+\+.+@users\.noreply\.github\.com'
           acknowledged-author-names--patterns: '\p{Lu}.*\s.+'
           acknowledged-committer-email-addresses--patterns: '\d+\+.+@users\.noreply\.github\.com'

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,20 @@
+= Changelog
+:experimental:
+:source-highlighter: highlight.js
+
+This file documents all notable changes to this project.
+The format is based on https://keepachangelog.com/en/1.1.0[Keep a Changelog], and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
+
+== https://github.com/rainstormy/github-action-deploy-with-rsync-over-ssh/compare/v1.0.1\...HEAD[Unreleased]
+
+== https://github.com/rainstormy/github-action-deploy-with-rsync-over-ssh/compare/v1.0.0\...v1.0.1[1.0.1] - 2023-05-06
+=== Added
+* https://choosealicense.com/licenses/mit[MIT license].
+
+=== Fixed
+* Verify that all input parameters have been defined.
+
+== https://github.com/rainstormy/github-action-deploy-with-rsync-over-ssh/releases/tag/v1.0.0[1.0.0] - 2023-04-10
+
+=== Added
+* GitHub Actions entrypoint.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Rainstorm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/action.yml
+++ b/action.yml
@@ -27,18 +27,65 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Verify declaration of input parameters
+      env:
+        RSYNC_DESTINATION_PATH: ${{ inputs.rsync-destination-path }}
+        RSYNC_HOST: ${{ inputs.rsync-host }}
+        RSYNC_OPTIONS: ${{ inputs.rsync-options }}
+        RSYNC_SOURCE_PATH: ${{ inputs.rsync-source-path }}
+        SSH_KNOWN_HOSTS: ${{ inputs.ssh-known-hosts }}
+        SSH_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
+        SSH_PRIVATE_KEY_FILENAME: ${{ inputs.ssh-private-key-filename }}
+      run: |
+        if [[ -z "$RSYNC_DESTINATION_PATH" ]]; then
+          echo "The input parameter 'rsync-destination-path' must be non-empty."
+          exit 1
+        fi
+        if [[ -z "$RSYNC_HOST" ]]; then
+          echo "The input parameter 'rsync-host' must be non-empty."
+          exit 1
+        fi
+        if [[ -z "$RSYNC_OPTIONS" ]]; then
+          echo "The input parameter 'rsync-options' must be non-empty."
+          exit 1
+        fi
+        if [[ -z "$RSYNC_SOURCE_PATH" ]]; then
+          echo "The input parameter 'rsync-source-path' must be non-empty."
+          exit 1
+        fi
+        if [[ -z "$SSH_KNOWN_HOSTS" ]]; then
+          echo "The input parameter 'ssh-known-hosts' must be non-empty."
+          exit 1
+        fi
+        if [[ -z "$SSH_PRIVATE_KEY" ]]; then
+          echo "The input parameter 'ssh-private-key' must be non-empty."
+          exit 1
+        fi
+        if [[ -z "$SSH_PRIVATE_KEY_FILENAME" ]]; then
+          echo "The input parameter 'ssh-private-key-filename' must be non-empty."
+          exit 1
+        fi
+      shell: bash
+
     - name: Prepare the SSH configuration
+      env:
+        SSH_KNOWN_HOSTS: ${{ inputs.ssh-known-hosts }}
+        SSH_PRIVATE_KEY: ${{ inputs.ssh-private-key }}
+        SSH_PRIVATE_KEY_FILENAME: ${{ inputs.ssh-private-key-filename }}
       run: |
         mkdir ~/.ssh
-        echo "${{ inputs.ssh-known-hosts }}" > ~/.ssh/known_hosts
+        echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
         chmod 644 ~/.ssh/known_hosts
-        echo "${{ inputs.ssh-private-key }}" > ~/.ssh/${{ inputs.ssh-private-key-filename }}
-        chmod 600 ~/.ssh/${{ inputs.ssh-private-key-filename }}
+        echo "$SSH_PRIVATE_KEY" > ~/.ssh/"$SSH_PRIVATE_KEY_FILENAME"
+        chmod 600 ~/.ssh/"$SSH_PRIVATE_KEY_FILENAME"
       shell: bash
 
     - name: Deploy with Rsync
+      env:
+        RSYNC_DESTINATION_PATH: ${{ inputs.rsync-destination-path }}
+        RSYNC_HOST: ${{ inputs.rsync-host }}
       run: |
-        rsync ${{ inputs.rsync-options }} ${{ inputs.rsync-source-path }} ${{ inputs.rsync-host }}:${{ inputs.rsync-destination-path }}
+        rsync ${{ inputs.rsync-options }} ${{ inputs.rsync-source-path }} "$RSYNC_HOST":"$RSYNC_DESTINATION_PATH"
       shell: bash
 
     - if: always()

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"license": "MIT",
 	"packageManager": "yarn@3.5.0",
 	"private": true
 }


### PR DESCRIPTION
This will prevent users from forgetting to specify input parameters.
This is particularly useful for the `ssh-private-key-filename` parameter
which defines a default value that you could override with an empty
GitHub Actions secret.

The use of temporary environment variables in GitHub Actions is good
practice to protect the shell script from script injection attacks.
However, the `rsync-options` and `rsync-source-path` input parameters
rely on being inlined as arguments to the rsync command to make the
`--rsh` option and glob expansion work correctly.

Normally, GitHub Actions will provide environment variables for input
parameters automatically. However, this is currently not the case for
composite actions, thus requiring them to be defined manually.